### PR TITLE
Force Modified GovernanceToken Compilation During Network Deploy

### DIFF
--- a/op-bindings/artifacts.json
+++ b/op-bindings/artifacts.json
@@ -43,7 +43,8 @@
     "ISemver",
     "StorageSetter",
     "SuperchainConfig",
-    "DataAvailabilityChallenge"
+    "DataAvailabilityChallenge",
+    "GovernanceToken"
   ],
   "remote": [
     {


### PR DESCRIPTION
GovernanceToken needs to be compiled as part of our deploy process, which Optimism upstream doesn't compile by default.