### PR TITLE
pin version for typescript and @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "prettier": "^2.8.0",
     "rimraf": "^5.0.5",
     "ts-mocha": "^10.0.0",
-    "typescript": "^5.3.3",
+    "typescript": "5.3.3",
     "wait-on": "^7.2.0"
   },
   "dependencies": {

--- a/packages/core-utils/package.json
+++ b/packages/core-utils/package.json
@@ -48,7 +48,7 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "@types/node": "^20.11.17",
+    "@types/node": "20.11.17",
     "mocha": "^10.2.0"
   }
 }


### PR DESCRIPTION
prior, the way we defined versions for both typescript and @node/types, it's possible that we could use a version higher than the minimum. that version could (did) introduce breaking changes.

pin them to a specific version in `package.json`