### PR TITLE
Special case for fee calculation for Hemi mainnet

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -421,7 +421,9 @@ func L1InfoDeposit(rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNumber 
 		// Apply Cancun blob base fee calculation if this chain needs the L1 Pectra
 		// blob schedule fix (mostly Holesky and Sepolia OP-Stack chains).
 		if t := rollupCfg.PectraBlobScheduleTime; t != nil && block.Time() < *t {
-			if ebg := block.ExcessBlobGas(); ebg != nil {
+			if rollupCfg.L2ChainID.Cmp(big.NewInt(43111)) == 0 && l2Timestamp < 1750870800 {
+				// Special case for Hemi mainnet, do nothing below this timestamp
+			} else if ebg := block.ExcessBlobGas(); ebg != nil {
 				l1BlockInfo.BlobBaseFee = eth.CalcBlobFeeCancun(*ebg)
 			} else {
 				// If L1 isn't on Cancun yet. It should already have been set


### PR DESCRIPTION
Ensures the Pectra Blob  Schedule legacy calculation is not enforced before timestamp 1750870800