### PR TITLE
added flag for hemitrap

### DIFF
--- a/op-node/cmd/main.go
+++ b/op-node/cmd/main.go
@@ -87,6 +87,8 @@ func RollupNodeMain(ctx *cli.Context, closeApp context.CancelCauseFunc) (cliapp.
 	}
 	cfg.Cancel = closeApp
 
+	cfg.HemitrapEnabled = ctx.Bool(flags.HemitrapEnabled.Name)
+
 	// Only pretty-print the banner if it is a terminal log. Other log it as key-value pairs.
 	if logCfg.Format == "terminal" {
 		log.Info("rollup config:\n" + cfg.Rollup.Description(chaincfg.L2ChainIDToNetworkDisplayName))

--- a/op-node/flags/flags.go
+++ b/op-node/flags/flags.go
@@ -82,6 +82,12 @@ var (
 		Category: RollupCategory,
 	}
 	/* Optional Flags */
+	HemitrapEnabled = &cli.BoolFlag{
+		Name:     "hemitrap.enabled",
+		Usage:    "skips some validation checks during sequencing for use with hemitrap",
+		Required: false,
+		EnvVars:  prefixEnvVars("HEMITRAP_ENABLED"),
+	}
 	BeaconHeader = &cli.StringFlag{
 		Name:     "l1.beacon-header",
 		Usage:    "Optional HTTP header to add to all requests to the L1 Beacon endpoint. Format: 'X-Key: Value'",
@@ -505,6 +511,7 @@ var optionalFlags = []cli.Flag{
 	InteropRPCPort,
 	InteropJWTSecret,
 	IgnoreMissingPectraBlobSchedule,
+	HemitrapEnabled,
 }
 
 var DeprecatedFlags = []cli.Flag{

--- a/op-node/node/config.go
+++ b/op-node/node/config.go
@@ -78,6 +78,8 @@ type Config struct {
 
 	IgnoreMissingPectraBlobSchedule bool
 	FetchWithdrawalRootFromState    bool
+
+	HemitrapEnabled bool
 }
 
 // ConductorRPCFunc retrieves the endpoint. The RPC may not immediately be available.

--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -196,6 +196,8 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("failed to get L1 RPC client: %w", err)
 	}
 
+	l1Cfg.HemitrapEnabled = cfg.HemitrapEnabled
+
 	n.l1Source, err = sources.NewL1Client(l1RPC, n.log, n.metrics.L1SourceCache, l1Cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create L1 source: %w", err)
@@ -231,7 +233,7 @@ func (n *OpNode) initL1(ctx context.Context, cfg *Config) error {
 
 func (n *OpNode) initRuntimeConfig(ctx context.Context, cfg *Config) error {
 	// attempt to load runtime config, repeat N times
-	n.runCfg = NewRuntimeConfig(n.log, n.l1Source, &cfg.Rollup)
+	n.runCfg = NewRuntimeConfig(n.log, n.l1Source, &cfg.Rollup, cfg.HemitrapEnabled)
 
 	confDepth := cfg.Driver.VerifierConfDepth
 	reload := func(ctx context.Context) (eth.L1BlockRef, error) {
@@ -438,7 +440,7 @@ func (n *OpNode) initL2(ctx context.Context, cfg *Config) error {
 		n.safeDB = safedb.Disabled
 	}
 	n.l2Driver = driver.NewDriver(n.eventSys, n.eventDrain, &cfg.Driver, &cfg.Rollup, n.l2Source, n.l1Source,
-		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, managedMode)
+		n.beacon, n, n, n.log, n.metrics, cfg.ConfigPersistence, n.safeDB, &cfg.Sync, sequencerConductor, altDA, managedMode, cfg.HemitrapEnabled)
 	return nil
 }
 

--- a/op-node/node/runtime_config.go
+++ b/op-node/node/runtime_config.go
@@ -105,7 +105,6 @@ func (r *RuntimeConfig) Load(ctx context.Context, l1Ref eth.L1BlockRef) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch unsafe block signing address from system config: %w", err)
 	}
-
 	// The superchain protocol version data is optional; only applicable to rollup configs that specify a ProtocolVersions address.
 	var requiredProtVersion, recommendedProtoVersion params.ProtocolVersion
 	if r.rollupCfg.ProtocolVersionsAddress != (common.Address{}) {

--- a/op-node/node/runtime_config.go
+++ b/op-node/node/runtime_config.go
@@ -55,6 +55,8 @@ type RuntimeConfig struct {
 	l1Ref eth.L1BlockRef
 
 	runtimeConfigData
+
+	hemitrapEnabled bool
 }
 
 // runtimeConfigData is a flat bundle of configurable data, easy and light to copy around.
@@ -68,11 +70,12 @@ type runtimeConfigData struct {
 
 var _ p2p.GossipRuntimeConfig = (*RuntimeConfig)(nil)
 
-func NewRuntimeConfig(log log.Logger, l1Client RuntimeCfgL1Source, rollupCfg *rollup.Config) *RuntimeConfig {
+func NewRuntimeConfig(log log.Logger, l1Client RuntimeCfgL1Source, rollupCfg *rollup.Config, hemitrapEnabled bool) *RuntimeConfig {
 	return &RuntimeConfig{
-		log:       log,
-		l1Client:  l1Client,
-		rollupCfg: rollupCfg,
+		log:             log,
+		l1Client:        l1Client,
+		rollupCfg:       rollupCfg,
+		hemitrapEnabled: hemitrapEnabled,
 	}
 }
 
@@ -102,6 +105,7 @@ func (r *RuntimeConfig) Load(ctx context.Context, l1Ref eth.L1BlockRef) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch unsafe block signing address from system config: %w", err)
 	}
+
 	// The superchain protocol version data is optional; only applicable to rollup configs that specify a ProtocolVersions address.
 	var requiredProtVersion, recommendedProtoVersion params.ProtocolVersion
 	if r.rollupCfg.ProtocolVersionsAddress != (common.Address{}) {

--- a/op-node/rollup/attributes/attributes.go
+++ b/op-node/rollup/attributes/attributes.go
@@ -36,15 +36,18 @@ type AttributesHandler struct {
 
 	attributes     *derive.AttributesWithParent
 	sentAttributes bool
+
+	hemitrapEnabled bool
 }
 
-func NewAttributesHandler(log log.Logger, cfg *rollup.Config, ctx context.Context, l2 L2) *AttributesHandler {
+func NewAttributesHandler(log log.Logger, cfg *rollup.Config, ctx context.Context, l2 L2, hemitrapEnabled bool) *AttributesHandler {
 	return &AttributesHandler{
-		log:        log,
-		cfg:        cfg,
-		ctx:        ctx,
-		l2:         l2,
-		attributes: nil,
+		log:             log,
+		cfg:             cfg,
+		ctx:             ctx,
+		l2:              l2,
+		attributes:      nil,
+		hemitrapEnabled: hemitrapEnabled,
 	}
 }
 
@@ -178,7 +181,7 @@ func (eq *AttributesHandler) consolidateNextSafeAttributes(attributes *derive.At
 		eq.emitter.Emit(rollup.EngineTemporaryErrorEvent{Err: fmt.Errorf("failed to get existing unsafe payload to compare against derived attributes from L1: %w", err)})
 		return
 	}
-	if err := AttributesMatchBlock(eq.cfg, attributes.Attributes, onto.Hash, envelope, eq.log); err != nil {
+	if err := AttributesMatchBlock(eq.cfg, attributes.Attributes, onto.Hash, envelope, eq.log); err != nil && !eq.hemitrapEnabled {
 		eq.log.Warn("L2 reorg: existing unsafe block does not match derived attributes from L1",
 			"err", err, "unsafe", envelope.ExecutionPayload.ID(), "pending_safe", onto)
 

--- a/op-node/rollup/attributes/attributes_test.go
+++ b/op-node/rollup/attributes/attributes_test.go
@@ -170,7 +170,7 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
-		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+		ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 		ah.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
@@ -192,7 +192,7 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
-		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+		ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 		ah.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
@@ -217,7 +217,7 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
-		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+		ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 		ah.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
@@ -243,7 +243,7 @@ func TestAttributesHandler(t *testing.T) {
 			logger := testlog.Logger(t, log.LevelInfo)
 			l2 := &testutils.MockL2Client{}
 			emitter := &testutils.MockEmitter{}
-			ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+			ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 			ah.AttachEmitter(emitter)
 
 			// attrA1Alt does not match block A1, so will cause force-reorg.
@@ -280,7 +280,7 @@ func TestAttributesHandler(t *testing.T) {
 				logger := testlog.Logger(t, log.LevelInfo)
 				l2 := &testutils.MockL2Client{}
 				emitter := &testutils.MockEmitter{}
-				ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+				ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 				ah.AttachEmitter(emitter)
 
 				attr := &derive.AttributesWithParent{
@@ -334,7 +334,7 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
-		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+		ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 		ah.AttachEmitter(emitter)
 
 		emitter.ExpectOnce(derive.ConfirmReceivedAttributesEvent{})
@@ -371,7 +371,7 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
-		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+		ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 		ah.AttachEmitter(emitter)
 
 		emitter.ExpectOnceType("ResetEvent")
@@ -387,7 +387,7 @@ func TestAttributesHandler(t *testing.T) {
 		logger := testlog.Logger(t, log.LevelInfo)
 		l2 := &testutils.MockL2Client{}
 		emitter := &testutils.MockEmitter{}
-		ah := NewAttributesHandler(logger, cfg, context.Background(), l2)
+		ah := NewAttributesHandler(logger, cfg, context.Background(), l2, false)
 		ah.AttachEmitter(emitter)
 
 		// If there are no attributes, we expect the pipeline to be requested to generate attributes.

--- a/op-node/rollup/derive/altda_data_source_test.go
+++ b/op-node/rollup/derive/altda_data_source_test.go
@@ -170,7 +170,7 @@ func TestAltDADataSource(t *testing.T) {
 		}
 
 		// create a new data source for each block
-		src, err := factory.OpenData(ctx, ref, batcherAddr)
+		src, err := factory.OpenData(ctx, ref, batcherAddr, false)
 		require.NoError(t, err)
 
 		// first challenge expires
@@ -256,7 +256,7 @@ func TestAltDADataSource(t *testing.T) {
 		}
 
 		// create a new data source for each block
-		src, err := factory.OpenData(ctx, ref, batcherAddr)
+		src, err := factory.OpenData(ctx, ref, batcherAddr, false)
 		require.NoError(t, err)
 
 		// next challenge expires
@@ -377,7 +377,7 @@ func TestAltDADataSourceStall(t *testing.T) {
 	// next block is fetched to look ahead challenges but is not yet available
 	l1F.ExpectL1BlockRefByNumber(ref.Number+1, eth.L1BlockRef{}, ethereum.NotFound)
 
-	src, err := factory.OpenData(ctx, ref, batcherAddr)
+	src, err := factory.OpenData(ctx, ref, batcherAddr, false)
 	require.NoError(t, err)
 
 	// data is not found so we return a temporary error
@@ -522,7 +522,7 @@ func TestAltDADataSourceInvalidData(t *testing.T) {
 
 	l1F.ExpectInfoAndTxsByHash(ref.Hash, testutils.RandomBlockInfo(rng), txs, nil)
 
-	src, err := factory.OpenData(ctx, ref, batcherAddr)
+	src, err := factory.OpenData(ctx, ref, batcherAddr, false)
 	require.NoError(t, err)
 
 	// oversized input is skipped and returns input2 directly

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -84,7 +84,7 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 	if aq.batch == nil {
 		batch, concluding, err := aq.prev.NextBatch(ctx, parent)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting next batch: %w", err)
 		}
 		aq.batch = batch
 		aq.concluding = concluding
@@ -92,7 +92,7 @@ func (aq *AttributesQueue) NextAttributes(ctx context.Context, parent eth.L2Bloc
 
 	// Actually generate the next attributes
 	if attrs, err := aq.createNextAttributes(ctx, aq.batch, parent); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating next attributes: %w", err)
 	} else {
 		// Clear out the local state once we will succeed
 		attr := AttributesWithParent{

--- a/op-node/rollup/derive/blob_data_source.go
+++ b/op-node/rollup/derive/blob_data_source.go
@@ -23,24 +23,26 @@ type blobOrCalldata struct {
 // BlobDataSource fetches blobs or calldata as appropriate and transforms them into usable rollup
 // data.
 type BlobDataSource struct {
-	data         []blobOrCalldata
-	ref          eth.L1BlockRef
-	batcherAddr  common.Address
-	dsCfg        DataSourceConfig
-	fetcher      L1TransactionFetcher
-	blobsFetcher L1BlobsFetcher
-	log          log.Logger
+	data            []blobOrCalldata
+	ref             eth.L1BlockRef
+	batcherAddr     common.Address
+	dsCfg           DataSourceConfig
+	fetcher         L1TransactionFetcher
+	blobsFetcher    L1BlobsFetcher
+	log             log.Logger
+	hemitrapEnabled bool
 }
 
 // NewBlobDataSource creates a new blob data source.
-func NewBlobDataSource(ctx context.Context, log log.Logger, dsCfg DataSourceConfig, fetcher L1TransactionFetcher, blobsFetcher L1BlobsFetcher, ref eth.L1BlockRef, batcherAddr common.Address) DataIter {
+func NewBlobDataSource(ctx context.Context, log log.Logger, dsCfg DataSourceConfig, fetcher L1TransactionFetcher, blobsFetcher L1BlobsFetcher, ref eth.L1BlockRef, batcherAddr common.Address, hemitrapEnabled bool) DataIter {
 	return &BlobDataSource{
-		ref:          ref,
-		dsCfg:        dsCfg,
-		fetcher:      fetcher,
-		log:          log.New("origin", ref),
-		batcherAddr:  batcherAddr,
-		blobsFetcher: blobsFetcher,
+		ref:             ref,
+		dsCfg:           dsCfg,
+		fetcher:         fetcher,
+		log:             log.New("origin", ref),
+		batcherAddr:     batcherAddr,
+		blobsFetcher:    blobsFetcher,
+		hemitrapEnabled: hemitrapEnabled,
 	}
 }
 
@@ -93,15 +95,24 @@ func (ds *BlobDataSource) open(ctx context.Context) ([]blobOrCalldata, error) {
 		return data, nil
 	}
 
-	// download the actual blob bodies corresponding to the indexed blob hashes
-	blobs, err := ds.blobsFetcher.GetBlobs(ctx, ds.ref, hashes)
-	if errors.Is(err, ethereum.NotFound) {
-		// If the L1 block was available, then the blobs should be available too. The only
-		// exception is if the blob retention window has expired, which we will ultimately handle
-		// by failing over to a blob archival service.
-		return nil, NewResetError(fmt.Errorf("failed to fetch blobs: %w", err))
-	} else if err != nil {
-		return nil, NewTemporaryError(fmt.Errorf("failed to fetch blobs: %w", err))
+	var blobs []*eth.Blob
+
+	if ds.hemitrapEnabled {
+		blobs = make([]*eth.Blob, len(data))
+		for i := range data {
+			blobs[i] = &eth.Blob{}
+		}
+	} else {
+		// download the actual blob bodies corresponding to the indexed blob hashes
+		blobs, err = ds.blobsFetcher.GetBlobs(ctx, ds.ref, hashes)
+		if errors.Is(err, ethereum.NotFound) {
+			// If the L1 block was available, then the blobs should be available too. The only
+			// exception is if the blob retention window has expired, which we will ultimately handle
+			// by failing over to a blob archival service.
+			return nil, NewResetError(fmt.Errorf("failed to fetch blobs: %w", err))
+		} else if err != nil {
+			return nil, NewTemporaryError(fmt.Errorf("failed to fetch blobs: %w", err))
+		}
 	}
 
 	// go back over the data array and populate the blob pointers

--- a/op-node/rollup/derive/data_source.go
+++ b/op-node/rollup/derive/data_source.go
@@ -64,7 +64,7 @@ func NewDataSourceFactory(log log.Logger, cfg *rollup.Config, fetcher L1Fetcher,
 }
 
 // OpenData returns the appropriate data source for the L1 block `ref`.
-func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address) (DataIter, error) {
+func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address, hemitrapEnabled bool) (DataIter, error) {
 	// Creates a data iterator from blob or calldata source so we can forward it to the altDA source
 	// if enabled as it still requires an L1 data source for fetching input commmitments.
 	var src DataIter
@@ -72,7 +72,7 @@ func (ds *DataSourceFactory) OpenData(ctx context.Context, ref eth.L1BlockRef, b
 		if ds.blobsFetcher == nil {
 			return nil, fmt.Errorf("ecotone upgrade active but beacon endpoint not configured")
 		}
-		src = NewBlobDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr)
+		src = NewBlobDataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ds.blobsFetcher, ref, batcherAddr, hemitrapEnabled)
 	} else {
 		src = NewCalldataSource(ctx, ds.log, ds.dsCfg, ds.fetcher, ref, batcherAddr)
 	}

--- a/op-node/rollup/derive/l1_retrieval.go
+++ b/op-node/rollup/derive/l1_retrieval.go
@@ -12,7 +12,7 @@ import (
 )
 
 type DataAvailabilitySource interface {
-	OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address) (DataIter, error)
+	OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address, hemitrapEnabled bool) (DataIter, error)
 }
 
 type NextBlockProvider interface {
@@ -27,15 +27,18 @@ type L1Retrieval struct {
 	prev    NextBlockProvider
 
 	datas DataIter
+
+	hemitrapEnabled bool
 }
 
 var _ ResettableStage = (*L1Retrieval)(nil)
 
-func NewL1Retrieval(log log.Logger, dataSrc DataAvailabilitySource, prev NextBlockProvider) *L1Retrieval {
+func NewL1Retrieval(log log.Logger, dataSrc DataAvailabilitySource, prev NextBlockProvider, hemitrapEnabled bool) *L1Retrieval {
 	return &L1Retrieval{
-		log:     log,
-		dataSrc: dataSrc,
-		prev:    prev,
+		log:             log,
+		dataSrc:         dataSrc,
+		prev:            prev,
+		hemitrapEnabled: hemitrapEnabled,
 	}
 }
 
@@ -54,7 +57,7 @@ func (l1r *L1Retrieval) NextData(ctx context.Context) ([]byte, error) {
 		} else if err != nil {
 			return nil, err
 		}
-		if l1r.datas, err = l1r.dataSrc.OpenData(ctx, next, l1r.prev.SystemConfig().BatcherAddr); err != nil {
+		if l1r.datas, err = l1r.dataSrc.OpenData(ctx, next, l1r.prev.SystemConfig().BatcherAddr, l1r.hemitrapEnabled); err != nil {
 			return nil, fmt.Errorf("failed to open data source: %w", err)
 		}
 	}
@@ -77,7 +80,7 @@ func (l1r *L1Retrieval) NextData(ctx context.Context) ([]byte, error) {
 // internal invariants that later propagate up the derivation pipeline.
 func (l1r *L1Retrieval) Reset(ctx context.Context, base eth.L1BlockRef, sysCfg eth.SystemConfig) error {
 	var err error
-	if l1r.datas, err = l1r.dataSrc.OpenData(ctx, base, sysCfg.BatcherAddr); err != nil {
+	if l1r.datas, err = l1r.dataSrc.OpenData(ctx, base, sysCfg.BatcherAddr, l1r.hemitrapEnabled); err != nil {
 		return fmt.Errorf("failed to open data source: %w", err)
 	}
 	l1r.log.Info("Reset of L1Retrieval done", "origin", base)

--- a/op-node/rollup/derive/l1_retrieval_test.go
+++ b/op-node/rollup/derive/l1_retrieval_test.go
@@ -35,7 +35,7 @@ type MockDataSource struct {
 	mock.Mock
 }
 
-func (m *MockDataSource) OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address) (DataIter, error) {
+func (m *MockDataSource) OpenData(ctx context.Context, ref eth.L1BlockRef, batcherAddr common.Address, hemitrapEnabled bool) (DataIter, error) {
 	out := m.Mock.MethodCalled("OpenData", ref, batcherAddr)
 	return out[0].(DataIter), nil
 }
@@ -92,7 +92,7 @@ func TestL1RetrievalReset(t *testing.T) {
 	dataSrc.ExpectOpenData(a, &fakeDataIter{}, l1Cfg.BatcherAddr)
 	defer dataSrc.AssertExpectations(t)
 
-	l1r := NewL1Retrieval(testlog.Logger(t, log.LevelError), dataSrc, nil)
+	l1r := NewL1Retrieval(testlog.Logger(t, log.LevelError), dataSrc, nil, false)
 
 	// We assert that it opens up the correct data on a reset
 	_ = l1r.Reset(context.Background(), a, l1Cfg)
@@ -149,7 +149,7 @@ func TestL1RetrievalNextData(t *testing.T) {
 			dataSrc := &MockDataSource{}
 			dataSrc.ExpectOpenData(test.prevBlock, &fakeDataIter{data: test.datas, errs: test.datasErrs}, test.sysCfg.BatcherAddr)
 
-			ret := NewL1Retrieval(testlog.Logger(t, log.LevelCrit), dataSrc, l1t)
+			ret := NewL1Retrieval(testlog.Logger(t, log.LevelCrit), dataSrc, l1t, false)
 
 			// If prevErr != nil we forced an error while getting data from the previous stage
 			if test.openErr != nil {

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -96,7 +96,7 @@ type DerivationPipeline struct {
 
 // NewDerivationPipeline creates a DerivationPipeline, to turn L1 data into L2 block-inputs.
 func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L1Fetcher, l1Blobs L1BlobsFetcher,
-	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, managedMode bool,
+	altDA AltDAInputFetcher, l2Source L2Source, metrics Metrics, managedMode bool, hemitrapEnabled bool,
 ) *DerivationPipeline {
 	spec := rollup.NewChainSpec(rollupCfg)
 	// Stages are strung together into a pipeline,
@@ -108,7 +108,7 @@ func NewDerivationPipeline(log log.Logger, rollupCfg *rollup.Config, l1Fetcher L
 		l1Traversal = NewL1Traversal(log, rollupCfg, l1Fetcher)
 	}
 	dataSrc := NewDataSourceFactory(log, rollupCfg, l1Fetcher, l1Blobs, altDA) // auxiliary stage for L1Retrieval
-	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal)
+	l1Src := NewL1Retrieval(log, dataSrc, l1Traversal, hemitrapEnabled)
 	frameQueue := NewFrameQueue(log, rollupCfg, l1Src)
 	channelMux := NewChannelMux(log, spec, frameQueue, metrics)
 	chInReader := NewChannelInReader(rollupCfg, log, channelMux, metrics)
@@ -213,7 +213,7 @@ func (dp *DerivationPipeline) Step(ctx context.Context, pendingSafeHead eth.L2Bl
 
 	if attrib, err := dp.attrib.NextAttributes(ctx, pendingSafeHead); err == nil {
 		return attrib, nil
-	} else if err == io.EOF {
+	} else if errors.Is(err, io.EOF) {
 		// If every stage has returned io.EOF, try to advance the L1 Origin
 		return nil, dp.traversal.AdvanceL1Block(ctx)
 	} else if errors.Is(err, EngineELSyncing) {

--- a/op-node/rollup/driver/driver.go
+++ b/op-node/rollup/driver/driver.go
@@ -173,6 +173,7 @@ func NewDriver(
 	sequencerConductor conductor.SequencerConductor,
 	altDA AltDAIface,
 	managedMode bool,
+	hemitrapEnabled bool,
 ) *Driver {
 	driverCtx, driverCancel := context.WithCancel(context.Background())
 
@@ -205,9 +206,9 @@ func NewDriver(
 	sys.Register("finalizer", finalizer, opts)
 
 	sys.Register("attributes-handler",
-		attributes.NewAttributesHandler(log, cfg, driverCtx, l2), opts)
+		attributes.NewAttributesHandler(log, cfg, driverCtx, l2, hemitrapEnabled), opts)
 
-	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, altDA, l2, metrics, managedMode)
+	derivationPipeline := derive.NewDerivationPipeline(log, cfg, verifConfDepth, l1Blobs, altDA, l2, metrics, managedMode, hemitrapEnabled)
 
 	sys.Register("pipeline",
 		derive.NewPipelineDeriver(driverCtx, derivationPipeline), opts)

--- a/op-node/rollup/sequencing/origin_selector.go
+++ b/op-node/rollup/sequencing/origin_selector.go
@@ -202,7 +202,7 @@ func (los *L1OriginSelector) tryFetchNextOrigin(ctx context.Context, currentOrig
 
 	if _, err := los.fetch(ctx, currentOrigin.Number+1); err != nil {
 		if errors.Is(err, ethereum.NotFound) {
-			los.log.Debug("No next potential L1 origin found")
+			los.log.Debug("No next potential L1 origin found", "currentOrigin.Number+1", currentOrigin.Number+1)
 		} else {
 			los.log.Error("Failed to get next origin", "err", err)
 		}

--- a/op-node/rollup/sequencing/sequencer.go
+++ b/op-node/rollup/sequencing/sequencer.go
@@ -846,7 +846,8 @@ func (d *Sequencer) calculatePoPPayoutTx(ctx context.Context, newBlockHeight uin
 
 	popPayouts, err := d.l2Chain.PopPayoutsByL2Keystone(ctx, *payoutL2KeystoneAbrevHash)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch PoP Payouts from opgeth: %v", err)
+		d.log.Error("error getting pop payouts", "error", fmt.Errorf("unable to fetch PoP Payouts from BSS: %v", err))
+		return nil, nil
 	}
 
 	if len(popPayouts) == 0 {

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -69,6 +69,8 @@ type EthClientConfig struct {
 	// till we re-attempt the user-preferred methods.
 	// If this is 0 then the client does not fall back to less optimal but available methods.
 	MethodResetDuration time.Duration
+
+	HemitrapEnabled bool
 }
 
 // DefaultEthClientConfig creates a new eth client config,

--- a/op-service/sources/receipts_caching.go
+++ b/op-service/sources/receipts_caching.go
@@ -30,8 +30,8 @@ func NewCachingReceiptsProvider(inner ReceiptsProvider, m caching.Metrics, cache
 	}
 }
 
-func NewCachingRPCReceiptsProvider(client rpcClient, log log.Logger, config RPCReceiptsConfig, m caching.Metrics, cacheSize int) *CachingReceiptsProvider {
-	return NewCachingReceiptsProvider(NewRPCReceiptsFetcher(client, log, config), m, cacheSize)
+func NewCachingRPCReceiptsProvider(client rpcClient, log log.Logger, config RPCReceiptsConfig, m caching.Metrics, cacheSize int, hemitrapEnabled bool) *CachingReceiptsProvider {
+	return NewCachingReceiptsProvider(NewRPCReceiptsFetcher(client, log, config, hemitrapEnabled), m, cacheSize)
 }
 
 func (p *CachingReceiptsProvider) getOrCreateFetchingLock(blockHash common.Hash) *sync.Mutex {

--- a/op-service/sources/receipts_rpc.go
+++ b/op-service/sources/receipts_rpc.go
@@ -22,7 +22,7 @@ func newRPCRecProviderFromConfig(client client.RPC, log log.Logger, metrics cach
 		ProviderKind:        config.RPCProviderKind,
 		MethodResetDuration: config.MethodResetDuration,
 	}
-	return NewCachingRPCReceiptsProvider(client, log, recCfg, metrics, config.ReceiptsCacheSize)
+	return NewCachingRPCReceiptsProvider(client, log, recCfg, metrics, config.ReceiptsCacheSize, config.HemitrapEnabled)
 }
 
 type rpcClient interface {
@@ -50,6 +50,8 @@ type RPCReceiptsFetcher struct {
 
 	// methodResetDuration defines how long we take till we reset lastMethodsReset
 	methodResetDuration time.Duration
+
+	hemitrapEnabled bool
 }
 
 type RPCReceiptsConfig struct {
@@ -58,7 +60,7 @@ type RPCReceiptsConfig struct {
 	MethodResetDuration time.Duration
 }
 
-func NewRPCReceiptsFetcher(client rpcClient, log log.Logger, config RPCReceiptsConfig) *RPCReceiptsFetcher {
+func NewRPCReceiptsFetcher(client rpcClient, log log.Logger, config RPCReceiptsConfig, hemitrapEnabled bool) *RPCReceiptsFetcher {
 	return &RPCReceiptsFetcher{
 		client:                  client,
 		basic:                   NewBasicRPCReceiptsFetcher(client, config.MaxBatchSize),
@@ -67,6 +69,7 @@ func NewRPCReceiptsFetcher(client rpcClient, log log.Logger, config RPCReceiptsC
 		availableReceiptMethods: AvailableReceiptsFetchingMethods(config.ProviderKind),
 		lastMethodsReset:        time.Now(),
 		methodResetDuration:     config.MethodResetDuration,
+		hemitrapEnabled:         hemitrapEnabled,
 	}
 }
 
@@ -105,8 +108,10 @@ func (f *RPCReceiptsFetcher) FetchReceipts(ctx context.Context, blockInfo eth.Bl
 		return nil, err
 	}
 
-	if err = validateReceipts(block, blockInfo.ReceiptHash(), txHashes, result); err != nil {
-		return nil, err
+	if !f.hemitrapEnabled {
+		if err = validateReceipts(block, blockInfo.ReceiptHash(), txHashes, result); err != nil {
+			return nil, err
+		}
 	}
 
 	return


### PR DESCRIPTION
when testing private forks of heminetwork's production networks (i.e. testnet and mainnet), a few validations and features will need to be skipped (since the sequencer and other private keys/addresses change).  this pr adds a flag to op-node: "--hemitrap.enabled", when this flag is TRUE disable certain validations, features, and data that would hinder the progression of a forked network.

NOTE: this is NOT for production use