### PR TITLE
do not override timeout in ForReceiptMaybe

### DIFF
--- a/op-e2e/e2eutils/wait/waits.go
+++ b/op-e2e/e2eutils/wait/waits.go
@@ -48,8 +48,6 @@ func ForReceipt(ctx context.Context, client *ethclient.Client, hash common.Hash,
 
 // ForReceiptMaybe waits for the receipt, but may be configured to ignore the status
 func ForReceiptMaybe(ctx context.Context, client *ethclient.Client, hash common.Hash, status uint64, statusIgnore bool) (*types.Receipt, error) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
optimism overrides context timeouts in (a lot of) test "wait" helper functions. one that we use use ForReceiptMaybe.  the timeout is hard-coded to 2 minutes.  but realistically when we "wait" sometimes what we're waiting for finishes in less than 2 minutes, sometimes longer.

remove this override.  use the context passed into the fuction for the timeout.