### PR TITLE
ci: pin actions to full-length commit hashes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,22 +24,22 @@ jobs:
       packages: write
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: "Setup QEMU"
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: "Setup Docker Buildx"
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: "Login to DockerHub"
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_TOKEN }}"
 
       - name: "Login to GitHub Container Registry"
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: "ghcr.io"
           username: "${{ github.repository_owner }}"
@@ -52,7 +52,7 @@ jobs:
           echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: "Build and push"
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: "${{ github.workspace }}"
           platforms: "amd64"


### PR DESCRIPTION
This pull request pins all GitHub Actions to their full-length commit SHAs. Used GitHub Actions have not been updated, and have been pinned to commit hashes for the latest release matching the existing tag.

The organisation-level setting "Require actions to be pinned to a full-length commit SHA" will be enabled on **January 15th, 2026**. Once this setting is active, any workflows referencing actions by tag (e.g., `@v4`) or branch (e.g., `@master`) will fail to execute.

Additionally, the setting "Allow hemilabs, and select non-hemilabs, actions and reusable workflows" will be enabled on the same date. All third-party actions currently in use by this repository have been recorded and will be permitted. **After January 15th, 2026, any new third-party actions must be approved by SecOps before use.**

Pinning actions to immutable commit hashes reduces potential for supply chain attacks by:
- Tag mutation attacks (where a malicious actor overwrites a tag with compromised code)
- Unexpected changes from upstream action updates

For more information, please see:

- [GitHub Docs: Secure use reference - Pin actions to a full-length commit SHA](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)
- [GitHub Well-Architected: Securing GitHub Actions Workflows](https://wellarchitected.github.com/library/application-security/recommendations/actions-security/)
- [GitHub Blog: Actions policy now supports blocking and SHA pinning](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)

All original version tags are preserved as inline comments for maintainability.

---

This pull request does not update any actions. Pinned actions:

| Action                       | Update | Change                    |
|------------------------------|--------|---------------------------|
| `actions/checkout`           | pin    | `v4 -> v4.3.1 (34e1148)`  |
| `docker/build-push-action`   | pin    | `v5 -> v5.4.0 (ca052bb)`  |
| `docker/login-action`        | pin    | `v3 -> v3.6.0 (5e57cd1)`  |
| `docker/setup-buildx-action` | pin    | `v3 -> v3.12.0 (8d2750c)` |
| `docker/setup-qemu-action`   | pin    | `v3 -> v3.7.0 (c7c5346)`  |

Detected third-party actions:
```
docker/build-push-action@v5.4.0
docker/login-action@v3.6.0
docker/setup-buildx-action@v3.12.0
docker/setup-qemu-action@v3.7.0
```